### PR TITLE
remove local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *_build
+*orig.tar.gz

--- a/README.md
+++ b/README.md
@@ -5,4 +5,25 @@ What is this?
 
 Packaging for debian (ubuntu really) was a mystery to me until @sneetsher helped me to figure it out. Check out `build.sh` to see how we are now packing prime_server into its library, devel and bin packages. It also has links and notes about how to get those packages onto your PPA. Enjoy and thanks again @sneetsher!
 
+What should I do?
+-----------------
 
+So you have a normal autotools project (maybe its c maybe its c++) and you want to turn it into a package behind a PPA. You want someone to be able to just add your ppa, and install your software without having to build it and know all the dependencies and all that fun stuff. Well I'm here to tell you you're out of luck.. You've probably searched around the internet to find a way to build this type of thing and ended up utterly confused. I was where you were and I'm hoping this README can help you.
+
+The first thing you need to do is look at this [http://packaging.ubuntu.com/html/index.html](http://packaging.ubuntu.com/html/index.html)
+
+It's got tons and tons of information in it but there are really only 2 parts that you'll probably need to worry about. The first thing you should do is follow the steps to setup a launchpad account: [http://packaging.ubuntu.com/html/getting-set-up.html](http://packaging.ubuntu.com/html/getting-set-up.html)
+
+When you're done with that you should have your fingerprint and your launchpad login squared away. When you are ready to put some code and packages into launchpad you'll want to head over to: [https://launchpad.net/~](https://launchpad.net/~)
+
+Click the link labled `Create new PPA` and give it a name. Mine was `prime_server`. Now you're ready to start building packages.
+
+There is actually a pretty nice tutorial on how to do this but the example is a bit trivial such that it doesn't teach you quite enough to get going. Specifically I wanted to build libs, dev and bins packages but it only shows you how to do bins. Here's that step by step process: [http://packaging.ubuntu.com/html/packaging-new-software.html](http://packaging.ubuntu.com/html/packaging-new-software.html)
+
+One thing that does come out of this is the creation and manual editing of the stuff in the `debian` directory. You'll want to do this at least once after which, you can squirrel that `debian` directory and your manual edits away because you can use it to create packages in an automated fashion.
+
+After utterly failing at using that to do what I wanted I posed a [question](http://packaging.ubuntu.com/html/packaging-new-software.html) on askubuntu.com which @sneetsher was kind enough to hand hold me through. Most of what was needed was proper editing of the contents of the `debian` directory. The result of that is this [script](//local.sh) and this [debian](//debian) directory. You'll see that it will basically build packages on your system for your specific version of Ubuntu. Extra work is needed to sign these and push them up to your PPA. Which, you could do, but then only users who are running your version of Ubuntu could make use of them. That's why someone created `pbuilder`.
+
+So `pbuilder` and its associated tools are awesome. They basically let you setup a vanilla environment of whatever version of Ubuntu you want (except Utopic for some reason...) for the purpose of testing out your package build. This is great because it basically lets you check to see if your package will be able to build on the launchpad servers. So with that information I threw together this [script](//build.sh). This will produce all the stuff you need to push to your ppa but wont actually push anything.
+
+To actually push stuff to your PPA you'll want to try out something like this [script](//publish.sh). This puts a branch with your code in your PPA (which is required or your packages won't be usable by others). It then signs (using the fingerprint you made with your launchpad account) and pushes your package sources to your PPA. Once pushed launchpad will accept or reject them, if accepted they'll build and hopefully pass and become available via your PPA. If rejected you'll get an email telling you why.

--- a/build.sh
+++ b/build.sh
@@ -1,62 +1,17 @@
 #!/bin/bash
 set -e
 
-#the main place for info on how to do this is here: http://packaging.ubuntu.com/html/index.html
-#section 2. launchpad here: http://packaging.ubuntu.com/html/getting-set-up.html
-#section 6. packaging here: http://packaging.ubuntu.com/html/packaging-new-software.html
-
-#massive thanks to @sneetsher for finding and fixing all of my mistakes!
-
-
 VERSION=$(cat version)
 RELEASES=$(cat releases)
 PACKAGE_VERSION=$(cat package_version)
 
 #get a bunch of stuff we'll need to  make the packages
-sudo apt-get install -y dh-make dh-autoreconf bzr-builddeb pbuilder ubuntu-dev-tools debootstrap devscripts
-#get the stuff we need to build the software
-sudo apt-get install -y autoconf automake pkg-config libtool make gcc g++ lcov libcurl4-openssl-dev libzmq3-dev
+sudo apt-get install -y git dh-make dh-autoreconf bzr-builddeb pbuilder ubuntu-dev-tools debootstrap devscripts
 
-#tell bzr who we are
-export DEBFULLNAME='Kevin Kreiser'
-export DEBEMAIL='kevinkreiser@gmail.com'
-bzr whoami "${DEBFULLNAME} <${DEBEMAIL}>"
-source /etc/lsb-release
-
-######################################################
-#SEE IF WE CAN BUILD THE PACKAGE FOR OUR LOCAL RELEASE
-rm -rf local_build
-mkdir local_build
-pushd local_build
 #get prime_server code into the form bzr likes
-git clone --branch ${VERSION} --recursive  https://github.com/kevinkreiser/prime_server.git
-tar pczf prime_server.tar.gz prime_server
-
-#start building the package, choose l(ibrary) for the type
-bzr dh-make libprime-server ${VERSION} prime_server.tar.gz << EOF
-l
-
-EOF
-
-#bzr will make you a template to fill out but who wants to do that manually?
-rm -rf libprime-server/debian
-cp -rp ../debian libprime-server
-sed -i -e "s/(.*) [a-z]\+;/(${VERSION}-${PACKAGE_VERSION}~${DISTRIB_CODENAME}1) ${DISTRIB_CODENAME};/g" libprime-server/debian/changelog
-
-#add the stuff to the bzr repository
-pushd libprime-server
-bzr add debian
-bzr commit -m "Initial commit of Debian packaging."
-
-#build the packages
-bzr builddeb -- -us -uc -j$(grep -c ^processor /proc/cpuinfo)
-
-#have to have a branch of the code up there or you cant use the ppa
-#bzr push lp:~kevinkreiser/+junk/prime-server-package
-popd
-popd
-######################################################
-
+git clone --branch ${VERSION} --recursive  https://github.com/kevinkreiser/prime_server.git libprime-server
+tar pczf libprime-server_${VERSION}.orig.tar.gz libprime-server
+rm -rf libprime-server
 
 ######################################################
 #LETS BUILD THE PACKAGE FOR SEVERAL RELEASES
@@ -66,38 +21,15 @@ for release in ${RELEASES}; do
 	pushd ${release}_build
 
 	#copy source targz
-	cp -rp ../local_build/libprime-server_${VERSION}.orig.tar.gz .
+	cp -rp ../libprime-server_${VERSION}.orig.tar.gz .
+	tar pxf libprime-server_${VERSION}.orig.tar.gz
 
-	#copy debian, update changelog and turn into a targz
-	cp -rp ../debian .
+	#build the dsc and source.change files
+	pushd libprime-server
+	cp -rp ../../debian .
 	sed -i -e "s/(.*) [a-z]\+;/(${VERSION}-${PACKAGE_VERSION}~${release}1) ${release};/g" debian/changelog
-	tar pczf libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.debian.tar.gz debian
-
-	#generate dsc file
-	echo "Format: $(cat debian/source/format)" > libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	grep -F Source: debian/control >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo "Binary: $(grep -F Package: debian/control | sed -e "s/Package: //g" | tr '\n' ' ' | sed -e "s/ $//g" -e "s/ /, /g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	grep -m1 -F Architecture: debian/control >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo "Version: ${VERSION}-${PACKAGE_VERSION}~${release}1" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	grep -F Maintainer: debian/control >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	grep -F Homepage: debian/control >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	grep -F Standards-Version: debian/control >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	grep -F Vcs-Git: debian/control >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	grep -F Build-Depends: debian/control >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo "Package-List: " >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	for package in $(grep -F Package: debian/control | sed -e "s/Package: //g" | tr '\n' ' '); do
-		section=$(tail -n +$(grep -m1 -n -F ${package} debian/control | cut -f1 -d:) debian/control | grep -m1 -F Section: | sed -e "s/Section: //g")
-		echo " ${package} deb ${section} $(grep -F Priority: debian/control | sed -e "s/Priority: //g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	done
-	echo "Checksums-Sha1: " >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo " $(sha1sum libprime-server_${VERSION}.orig.tar.gz | sed -e "s/ \+/ $(wc -c < libprime-server_${VERSION}.orig.tar.gz) /g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo " $(sha1sum libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.debian.tar.gz | sed -e "s/ \+/ $(wc -c < libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.debian.tar.gz) /g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-        echo "Checksums-Sha256: " >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo " $(sha256sum libprime-server_${VERSION}.orig.tar.gz | sed -e "s/ \+/ $(wc -c < libprime-server_${VERSION}.orig.tar.gz) /g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo " $(sha256sum libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.debian.tar.gz | sed -e "s/ \+/ $(wc -c < libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.debian.tar.gz) /g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-        echo "Files: " >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo " $(md5sum libprime-server_${VERSION}.orig.tar.gz | sed -e "s/ \+/ $(wc -c < libprime-server_${VERSION}.orig.tar.gz) /g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
-	echo " $(md5sum libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.debian.tar.gz | sed -e "s/ \+/ $(wc -c < libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.debian.tar.gz) /g")" >> libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
+	debuild -S -uc -sa
+	popd
 
 	#make sure we support this release
 	if [ ! -e ~/pbuilder/${release}-base.tgz ]; then

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ for release in ${RELEASES}; do
 	fi
 
 	#try to build a package for it
-	pbuilder-dist ${release} build libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
+	DEB_BUILD_OPTIONS="parallel=$(nproc)" pbuilder-dist ${release} build libprime-server_${VERSION}-${PACKAGE_VERSION}~${release}1.dsc
 	popd
 done
 ######################################################

--- a/local.sh
+++ b/local.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+#the main place for info on how to do this is here: http://packaging.ubuntu.com/html/index.html
+#section 2. launchpad here: http://packaging.ubuntu.com/html/getting-set-up.html
+#section 6. packaging here: http://packaging.ubuntu.com/html/packaging-new-software.html
+
+#massive thanks to @sneetsher for finding and fixing all of my mistakes!
+
+
+VERSION=$(cat version)
+RELEASES=$(cat releases)
+PACKAGE_VERSION=$(cat package_version)
+
+#get a bunch of stuff we'll need to  make the packages
+sudo apt-get install -y dh-make dh-autoreconf bzr-builddeb pbuilder ubuntu-dev-tools debootstrap devscripts
+#get the stuff we need to build the software
+sudo apt-get install -y autoconf automake pkg-config libtool make gcc g++ lcov libcurl4-openssl-dev libzmq3-dev
+
+#tell bzr who we are
+export DEBFULLNAME='Kevin Kreiser'
+export DEBEMAIL='kevinkreiser@gmail.com'
+bzr whoami "${DEBFULLNAME} <${DEBEMAIL}>"
+source /etc/lsb-release
+
+######################################################
+#SEE IF WE CAN BUILD THE PACKAGE FOR OUR LOCAL RELEASE
+rm -rf local_build
+mkdir local_build
+pushd local_build
+#get prime_server code into the form bzr likes
+git clone --branch ${VERSION} --recursive  https://github.com/kevinkreiser/prime_server.git
+tar pczf prime_server.tar.gz prime_server
+
+#start building the package, choose l(ibrary) for the type
+bzr dh-make libprime-server ${VERSION} prime_server.tar.gz << EOF
+l
+
+EOF
+
+#bzr will make you a template to fill out but who wants to do that manually?
+rm -rf libprime-server/debian
+cp -rp ../debian libprime-server
+sed -i -e "s/(.*) [a-z]\+;/(${VERSION}-${PACKAGE_VERSION}~${DISTRIB_CODENAME}1) ${DISTRIB_CODENAME};/g" libprime-server/debian/changelog
+
+#add the stuff to the bzr repository
+pushd libprime-server
+bzr add debian
+bzr commit -m "Packaging for ${VERSION}-${PACKAGE_VERSION}."
+
+#build the packages
+bzr builddeb -- -us -uc -j$(grep -c ^processor /proc/cpuinfo)
+popd
+popd
+######################################################
+

--- a/local.sh
+++ b/local.sh
@@ -49,7 +49,7 @@ bzr add debian
 bzr commit -m "Packaging for ${VERSION}-${PACKAGE_VERSION}."
 
 #build the packages
-bzr builddeb -- -us -uc -j$(grep -c ^processor /proc/cpuinfo)
+bzr builddeb -- -us -uc -j$(nproc)
 popd
 popd
 ######################################################

--- a/publish.sh
+++ b/publish.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
-
 set -e
 
 VERSION=$(cat version)
-RELEASES=$(cat releases)
+RELEASES=( $(cat releases) )
 PACKAGE_VERSION=$(cat package_version)
 
-#sign each package
-for release in ${RELEASES}; do
-	pushd ~/pbuilder/${release}_result
-	debsign libprime-server_${VERSION}-${PACKAGE_VERSION}_source.changes
-	popd
-done
+#have to have a branch of the code up there or the packages wont work from the ppa
+pushd ${RELEASES[0]}_build/libprime-server
+bzr init
+bzr add
+bzr commit -m "Packaging for ${VERSION}-${PACKAGE_VERSION}."
+bzr push --overwrite lp:~kevinkreiser/+junk/prime-server_${VERSION}-${PACKAGE_VERSION}
+popd
 
-#push each package to launchpad
-for release in ${RELEASES}; do
-	pushd ~/pbuilder/${release}_result
-	dput ppa:kevinkreiser/prime-server libprime-server_${VERSION}-${PACKAGE_VERSION}_source.changes
-	popd
+#sign and push each package to launchpad
+for release in ${RELEASES[@]}; do
+	debsign ${release}_build/*source.changes
+	dput ppa:kevinkreiser/prime-server ${release}_build/*source.changes
 done


### PR DESCRIPTION
this moves the local build to its own script. its not strictly needed and therefore is not part of the CI build any more. now we just use `debuild` and `pbuilder-dist` for all of our checking-the-stuff-builds-properly needs.

also we've got a packaging script that should properly work now as well.
